### PR TITLE
Upgrade JSimpleShell to 4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 osiamConnectorVersion=1.7-SNAPSHOT
-jSimpleShellVersion=3.0.2
+jSimpleShellVersion=4.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 18 17:09:16 CEST 2015
+#Wed Aug 19 16:15:52 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/src/main/java/org/osiam/shell/Starter.java
+++ b/src/main/java/org/osiam/shell/Starter.java
@@ -60,7 +60,7 @@ public class Starter {
 								.addAuxHandler(new X509CertificateConverter())
 								.addAuxHandler(new DateConverter())
 								.addAuxHandler(new URIConverter())
-							.back().build();
+							.build();
 
 		shell.processLine("?help");
 		shell.commandLoop();

--- a/src/main/java/org/osiam/shell/command/ConnectionCommand.java
+++ b/src/main/java/org/osiam/shell/command/ConnectionCommand.java
@@ -142,7 +142,7 @@ public class ConnectionCommand extends AbstractOsiamCommand {
 		final Shell subshell = ShellBuilder.subshell(getHostName(connector), shell)
 								.behavior()
 									.addHandler(new LoginCommand(connector))
-								.back().build();
+								.build();
 
 		subshell.commandLoop();
 	}

--- a/src/main/java/org/osiam/shell/command/LoginCommand.java
+++ b/src/main/java/org/osiam/shell/command/LoginCommand.java
@@ -86,7 +86,7 @@ public class LoginCommand extends AbstractOsiamCommand {
 									.addHandler(new UpdateUserCommand(at, connector))
 									.addHandler(new DeleteGroupCommand(at, connector))
 									.addHandler(new DeleteUserCommand(at, connector))
-								.back().build();
+								.build();
 
 		subshell.commandLoop();
 	}

--- a/src/main/java/org/osiam/shell/command/builder/BuilderShellFactory.java
+++ b/src/main/java/org/osiam/shell/command/builder/BuilderShellFactory.java
@@ -47,7 +47,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(nameBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an name. Leave this sub shell via \"commit\" to persist the changes.")
@@ -82,7 +82,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(addressBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an address. Leave this sub shell via \"commit\" to persist the changes.")
@@ -117,7 +117,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(emailBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an email. Leave this sub shell via \"commit\" to persist the changes.")
@@ -152,7 +152,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(entitlementBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an entitlement. Leave this sub shell via \"commit\" to persist the changes.")
@@ -170,7 +170,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(extensionBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an extension. Leave this sub shell via \"commit\" to persist the changes.")
@@ -205,7 +205,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(imBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create an im. Leave this sub shell via \"commit\" to persist the changes.")
@@ -240,7 +240,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(phoneNumberBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create a phone-number. Leave this sub shell via \"commit\" to persist the changes.")
@@ -275,7 +275,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(photoBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create a photo. Leave this sub shell via \"commit\" to persist the changes.")
@@ -310,7 +310,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(roleBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create a role. Leave this sub shell via \"commit\" to persist the changes.")
@@ -345,7 +345,7 @@ public class BuilderShellFactory {
 			.behavior()
 				.disableExitCommand()
 				.addHandler(x509CertificateBuilder)
-			.back().build();
+			.build();
 
 		output.out()
 			.normal("In this subshell you can create a certificate. Leave this sub shell via \"commit\" to persist the changes.")

--- a/src/main/java/org/osiam/shell/command/create/CreateGroupCommand.java
+++ b/src/main/java/org/osiam/shell/command/create/CreateGroupCommand.java
@@ -50,7 +50,7 @@ public class CreateGroupCommand extends OsiamAccessCommand implements ShellDepen
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can build your group. Leave this sub shell to persist the group.")
@@ -92,7 +92,7 @@ public class CreateGroupCommand extends OsiamAccessCommand implements ShellDepen
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can build your group. Leave this sub shell to persist the group.")

--- a/src/main/java/org/osiam/shell/command/create/CreateUserCommand.java
+++ b/src/main/java/org/osiam/shell/command/create/CreateUserCommand.java
@@ -55,7 +55,7 @@ public class CreateUserCommand extends OsiamAccessCommand implements ShellDepend
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can create a new user. Leave this sub shell via \"commit\" to persist the changes.")
@@ -97,7 +97,7 @@ public class CreateUserCommand extends OsiamAccessCommand implements ShellDepend
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can create a new user. Leave this sub shell via \"commit\" to persist the changes.")

--- a/src/main/java/org/osiam/shell/command/select/SelectGroupCommand.java
+++ b/src/main/java/org/osiam/shell/command/select/SelectGroupCommand.java
@@ -95,7 +95,7 @@ public class SelectGroupCommand extends OsiamAccessCommand implements ShellDepen
 		final Shell subShell = ShellBuilder.subshell(prompt.toString(), shell)
 								.behavior()
 									.addHandler(new GroupSearchResultCommand(accessToken, connector, builder.build()))
-								.back().build();
+								.build();
 
 		subShell.processLine(GroupSearchResultCommand.COMMAND_NAME_NEXT);
 		subShell.commandLoop();

--- a/src/main/java/org/osiam/shell/command/select/SelectUserCommand.java
+++ b/src/main/java/org/osiam/shell/command/select/SelectUserCommand.java
@@ -90,7 +90,7 @@ public class SelectUserCommand extends OsiamAccessCommand implements ShellDepend
 		final Shell subShell = ShellBuilder.subshell(prompt.toString(), shell)
 								.behavior()
 									.addHandler(new UserSearchResultCommand(accessToken, connector, builder.build()))
-								.back().build();
+								.build();
 
 		subShell.processLine(UserSearchResultCommand.COMMAND_NAME_NEXT);
 		subShell.commandLoop();

--- a/src/main/java/org/osiam/shell/command/update/UpdateGroupCommand.java
+++ b/src/main/java/org/osiam/shell/command/update/UpdateGroupCommand.java
@@ -63,7 +63,7 @@ public class UpdateGroupCommand extends OsiamAccessCommand implements ShellDepen
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can edit the group. Leave this sub shell via \"commit\" to persist the changes.")

--- a/src/main/java/org/osiam/shell/command/update/UpdateUserCommand.java
+++ b/src/main/java/org/osiam/shell/command/update/UpdateUserCommand.java
@@ -68,7 +68,7 @@ public class UpdateUserCommand extends OsiamAccessCommand implements ShellDepend
 								.behavior()
 									.disableExitCommand()
 									.addHandler(builder)
-								.back().build();
+								.build();
 
 		output.out()
 			.normal("In this subshell you can edit the user. Leave this sub shell via \"commit\" to persist the changes.")


### PR DESCRIPTION
Since version 4.0 changed the public api, the `back()` calls must be
removed in order to build the project with the new dependency.